### PR TITLE
Add goreleaser support to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 go:
-  - 1.6
-  - 1.7
   - 1.8.x
+after_success:
+  test -n "$TRAVIS_TAG" && curl -sL https://git.io/goreleaser | bash


### PR DESCRIPTION
also removes older go versions, for now